### PR TITLE
PPT/2型評価関数の差分計算

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "encoding",
  "rand",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 
 [profile.release]

--- a/engine/bakuretsu_komahiroi_taro/src/evaluate.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/evaluate.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
-use shogi_core::{Color, Piece, PieceKind, Square};
+use shogi_core::{Color, Move, Piece, PieceKind, Square};
 use yasai::Position;
 
-const VALUE_SCALE: f32 = 512.;
+pub const VALUE_SCALE: f32 = 512.;
 
 #[derive(Deserialize, Serialize)]
 pub struct EvalJson {
@@ -52,52 +52,208 @@ impl Evaluate {
         Evaluate { model }
     }
 
-    pub fn inference(&self, pos: &Position) -> i32 {
-        //! 局面を評価する
+    pub fn inference_diff(&self, pos: &Position, mv: Option<Move>, value: Option<f32>) -> f32 {
+        //! 局面を差分評価する
         //!
         //! - Arguments
         //!   - pos: &Position
         //!     - 評価したい局面
-        //!
+        //!   - mv: Move
+        //!     - posからの指し手
+        //!   - mut value: f32
+        //!     - posの評価値
         //! - Returns
         //!   - value: i32
         //!     - 評価値
 
-        let mut value = 0.;
+        // 差分計算元がない場合
+        if mv.is_none() || value.is_none() {
+            let mut value = 0.;
 
-        let mut sqs_pcs: Vec<(Square, Piece)> = Vec::new();
-        for sq in Square::all() {
-            let pc = pos.piece_at(sq);
-            if let Some(pc) = pc {
-                sqs_pcs.push((sq, pc));
-            }
-        }
-        for (sq1, pc1) in sqs_pcs.iter() {
-            for (sq2, pc2) in sqs_pcs.iter() {
-                if sq1.array_index() > sq2.array_index() {
-                    continue;
+            let mut sqs_pcs: Vec<(Square, Piece)> = Vec::new();
+            for sq in Square::all() {
+                let pc = pos.piece_at(sq);
+                if let Some(pc) = pc {
+                    sqs_pcs.push((sq, pc));
                 }
-                value += self.model[0][sq1.array_index()][pc1.as_u8() as usize][sq2.array_index()]
-                    [pc2.as_u8() as usize];
             }
+            for (sq1, pc1) in sqs_pcs.iter() {
+                for (sq2, pc2) in sqs_pcs.iter() {
+                    if sq1.array_index() > sq2.array_index() {
+                        continue;
+                    }
+                    value += self.model[0][sq1.array_index()][pc1.as_u8() as usize]
+                        [sq2.array_index()][pc2.as_u8() as usize];
+                }
+            }
+
+            let mut idx = 81;
+            for color in Color::all() {
+                let hand = pos.hand(color);
+                for piece_type in PieceKind::all() {
+                    if piece_type == PieceKind::King {
+                        break;
+                    }
+                    let count = hand.Hand_count(piece_type) as usize;
+                    if count != 0 {
+                        value += self.model[0][0][0][idx][count];
+                    }
+                    idx += 1;
+                }
+            }
+
+            return value;
         }
 
-        let mut idx = 81;
-        for color in Color::all() {
-            let hand = pos.hand(color);
-            for piece_type in PieceKind::all() {
-                if piece_type == PieceKind::King {
-                    break;
+        let mv = if let Some(mv) = mv {
+            mv
+        } else {
+            panic!("mv == None")
+        };
+        let mut value = if let Some(value) = value {
+            value
+        } else {
+            panic!("value == None")
+        };
+        // 盤面の駒を動かす場合
+        if let Move::Normal { from, to, promote } = mv {
+            let from_piece = if let Some(from_piece) = pos.piece_at(from) {
+                from_piece
+            } else {
+                panic!("Can not move the piece.");
+            };
+            let from_to_piece = if promote {
+                if let Some(from_to_piece) = from_piece.promote() {
+                    from_to_piece
+                } else {
+                    panic!("Can not promote the piece.");
                 }
-                let count = hand.Hand_count(piece_type) as usize;
-                if count != 0 {
-                    value += self.model[0][0][0][idx][count];
+            } else {
+                from_piece
+            };
+            // 盤面の差分計算
+            for sq in Square::all() {
+                if let Some(pc) = pos.piece_at(sq) {
+                    // 移動元
+                    if sq.array_index() <= from.array_index() {
+                        value -= self.model[0][sq.array_index()][pc.as_u8() as usize]
+                            [from.array_index()][from_piece.as_u8() as usize];
+                    } else {
+                        value -= self.model[0][from.array_index()][from_piece.as_u8() as usize]
+                            [sq.array_index()][pc.as_u8() as usize];
+                    }
+                    // 移動先
+                    if sq.array_index() <= to.array_index() {
+                        value += self.model[0][sq.array_index()][pc.as_u8() as usize]
+                            [to.array_index()][from_to_piece.as_u8() as usize];
+                    } else {
+                        value += self.model[0][to.array_index()][from_to_piece.as_u8() as usize]
+                            [sq.array_index()][pc.as_u8() as usize];
+                    }
                 }
-                idx += 1;
             }
+            // 移動元×移動先の2駒関係が過剰に足されているので引く
+            if from.array_index() <= to.array_index() {
+                value -= self.model[0][from.array_index()][from_piece.as_u8() as usize]
+                    [to.array_index()][from_to_piece.as_u8() as usize];
+            } else {
+                value -= self.model[0][to.array_index()][from_to_piece.as_u8() as usize]
+                    [from.array_index()][from_piece.as_u8() as usize];
+            }
+            // 移動先の1駒関係が足せていないのでここで足す
+            value += self.model[0][to.array_index()][from_to_piece.as_u8() as usize]
+                [to.array_index()][from_to_piece.as_u8() as usize];
+
+            // 駒取りの場合は追加
+            if let Some(to_piece) = pos.piece_at(to) {
+                //盤面の駒取り
+                for sq in Square::all() {
+                    if let Some(pc) = pos.piece_at(sq) {
+                        // 移動先
+                        if sq.array_index() <= to.array_index() {
+                            value -= self.model[0][sq.array_index()][pc.as_u8() as usize]
+                                [to.array_index()][to_piece.as_u8() as usize];
+                        } else {
+                            value -= self.model[0][to.array_index()][to_piece.as_u8() as usize]
+                                [sq.array_index()][pc.as_u8() as usize];
+                        }
+                    }
+                }
+                // 移動元×移動先の2駒関係が過剰に引かれているので足す
+                if from.array_index() <= to.array_index() {
+                    value += self.model[0][from.array_index()][from_piece.as_u8() as usize]
+                        [to.array_index()][to_piece.as_u8() as usize];
+                } else {
+                    value += self.model[0][to.array_index()][to_piece.as_u8() as usize]
+                        [from.array_index()][from_piece.as_u8() as usize];
+                }
+                // 持ち駒
+                let turn = pos.side_to_move();
+                let idx = match turn {
+                    Color::Black => 81,
+                    Color::White => 88,
+                };
+                let piece_kind = to_piece.piece_kind();
+                let piece_kind = if let Some(piece_kind) = piece_kind.unpromote() {
+                    piece_kind
+                } else {
+                    piece_kind
+                };
+                let count = pos.hand(turn).count(piece_kind);
+                if let Some(count) = count {
+                    value +=
+                        self.model[0][0][0][idx + piece_kind.array_index()][count as usize + 1];
+                    if count > 0 {
+                        value -=
+                            self.model[0][0][0][idx + piece_kind.array_index()][count as usize];
+                    }
+                } else {
+                    panic!("Can not capture piece.");
+                }
+            }
+
+            return value;
         }
 
-        (value * VALUE_SCALE) as i32
+        // 駒打ちの場合
+        if let Move::Drop { piece, to } = mv {
+            // 持ち駒の差分評価
+            let turn = pos.side_to_move();
+            let idx = match turn {
+                Color::Black => 81,
+                Color::White => 88,
+            };
+            let piece_kind = piece.piece_kind();
+            let count = pos.hand(turn).count(piece_kind);
+            if let Some(count) = count {
+                value -= self.model[0][0][0][idx + piece_kind.array_index()][count as usize];
+                if count > 1 {
+                    value +=
+                        self.model[0][0][0][idx + piece_kind.array_index()][count as usize - 1];
+                }
+            } else {
+                panic!("A piece not in the hand was used.");
+            }
+            // 盤面の差分計算
+            for sq in Square::all() {
+                if let Some(pc) = pos.piece_at(sq) {
+                    if sq.array_index() <= to.array_index() {
+                        value += self.model[0][sq.array_index()][pc.as_u8() as usize]
+                            [to.array_index()][piece.as_u8() as usize];
+                    } else {
+                        value += self.model[0][to.array_index()][piece.as_u8() as usize]
+                            [sq.array_index()][pc.as_u8() as usize];
+                    }
+                }
+            }
+            // 移動先の1駒関係が足せていないのでここで足す
+            value += self.model[0][to.array_index()][piece.as_u8() as usize][to.array_index()]
+                [piece.as_u8() as usize];
+
+            return value;
+        }
+
+        unreachable!("Can not perform differential inference.");
     }
 }
 
@@ -121,8 +277,8 @@ mod tests {
         let pos = Position::default();
 
         let eval = Evaluate::new(path);
-        let value = eval.inference(&pos);
+        let value = eval.inference_diff(&pos, None, None);
 
-        assert!(value == 0);
+        assert!(value == 0.0);
     }
 }

--- a/engine/bakuretsu_komahiroi_taro/src/main.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/main.rs
@@ -244,6 +244,7 @@ impl BakuretsuKomahiroiTaro {
                     piece_to_history: vec![vec![vec![0; 81]; 14]; 2],
                     killer_heuristic: vec![vec![None; 2]; self.depth_limit as usize + 1],
                 },
+                position_history: position_history.clone(),
             }
         } else {
             panic!("Cannot load evaluate model.");
@@ -256,11 +257,12 @@ impl BakuretsuKomahiroiTaro {
 
         // 通常の探索
         let mut best_move = "resign".to_string();
+        let mut position_value = vec![nega.eval.inference_diff(pos, None, None); 1];
         for depth in 1..=self.depth_limit {
             nega.max_depth = depth;
             let value = nega.search(
                 pos,
-                position_history,
+                &mut position_value,
                 false,
                 depth,
                 -MATING_VALUE,


### PR DESCRIPTION
#40 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `engine/bakuretsu_komahiroi_taro/Cargo.toml`のバージョン番号が2.0.0から2.1.0に変更されました。
- Refactor: `engine/bakuretsu_komahiroi_taro/src/main.rs`で、`BakuretsuKomahiroiTaro`構造体の初期化時に`position_history`をコピーする変更が行われました。また、`nega.search`メソッドの呼び出し時にも`position_value`が参照渡しで渡されるようになりました。
- New Feature: `engine/bakuretsu_komahiroi_taro/src/search.rs`に`evaluate_diff`関数が追加され、`NegaAlpha`構造体に`position_history`フィールドが追加されました。`evaluate_diff`関数は局面の差分評価を行い、`position_value`引数を使用して局面の評価値を取得します。`quiescence_search`と`search`関数内で`evaluate`関数の代わりに`evaluate_diff`関数が呼び出されるように変更されました。

Note: これらの変更は、パフォーマンスや一貫性の向上、新機能の追加、リファクタリングが行われたことを示しています。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->