### PR TITLE
Late Move Reductionsの実装

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "2.1.0"
+version = "2.2.0"
 dependencies = [
  "encoding",
  "rand",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "2.1.0"
+version = "2.2.0"
 edition = "2021"
 
 [profile.release]


### PR DESCRIPTION
#42 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

- Refactor: `engine/bakuretsu_komahiroi_taro/Cargo.toml`のバージョン番号が2.1.0から2.2.0に変更されました。
- New Feature: `engine/bakuretsu_komahiroi_taro/src/search.rs`にLate Move Reductions（LMR）の実装が追加されました。これにより、探索の最適化が行われ、パフォーマンスが向上しました。

Note: この回答はリリースノートとして使用するため、追加のコメントは避けてください。
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->