### PR TITLE
コードレビューに使用するmodelをgpt-4-turbo-previewに変更

### DIFF
--- a/.github/workflows/coderabbit.yml
+++ b/.github/workflows/coderabbit.yml
@@ -30,8 +30,8 @@ jobs:
           debug: false
           review_simple_changes: false
           review_comment_lgtm: false
-          openai_light_model: gpt-3.5-turbo # 好きに変更して
-          openai_heavy_model: gpt-3.5-turbo # 好きに変更して。本家曰く、gpt-4 推奨（ただし、値段に注意）
+          openai_light_model: gpt-4-turbo-preview # 好きに変更して
+          openai_heavy_model: gpt-4-turbo-preview # 好きに変更して。本家曰く、gpt-4 推奨（ただし、値段に注意）
           openai_timeout_ms: 900000 # 15 mins. Timeout for OpenAI API call in millis
           language: ja-JP
           path_filters: |


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- New Feature: GitHub Actionsの設定ファイルにおいて、OpenAI APIのモデルを`gpt-3.5-turbo`から最新の`gpt-4-turbo-preview`に更新しました。これにより、より高度な自然言語処理能力と改善されたパフォーマンスを提供します。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->