### PR TITLE
爆裂駒拾太郎V2.2.2

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
  "arrayvec",
  "encoding",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "2.2.1"
+version = "2.2.2"
 edition = "2021"
 
 [profile.release]

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,8 +15,10 @@ idna==3.4
 isort==5.13.2
 Jinja2==3.1.2
 llvmlite==0.41.1
+markdown-it-py==3.0.0
 MarkupSafe==2.1.3
 mccabe==0.7.0
+mdurl==0.1.2
 mpmath==1.3.0
 mypy==1.8.0
 mypy-extensions==1.0.0
@@ -29,8 +31,10 @@ Pillow==9.3.0
 platformdirs==4.1.0
 pycodestyle==2.11.1
 pyflakes==3.1.0
+Pygments==2.17.2
 pysen==0.10.5
 requests==2.28.1
+rich==13.7.0
 smmap==5.0.1
 sympy==1.12
 tomlkit==0.12.3

--- a/train/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/train/bakuretsu_komahiroi_taro/Cargo.lock
@@ -4,9 +4,9 @@ version = 3
 
 [[package]]
 name = "arrayvec"
-version = "0.7.2"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+checksum = "96d30a06541fbafbc7f82ed10c06164cfbd2c401138f6addd8404629c4b16711"
 
 [[package]]
 name = "autocfg"
@@ -16,8 +16,9 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
+ "arrayvec",
  "encoding",
  "rand",
  "rand_distr",
@@ -285,7 +286,7 @@ checksum = "fd6fbd9a79829dd1ad0cc20627bf1ed606756a7f77edff7b66b7064f9cb327c6"
 [[package]]
 name = "yasai"
 version = "0.5.0"
-source = "git+https://github.com/burokoron/yasai/?rev=d38d6592a422ba9902204b74b2d1901a97166f10#d38d6592a422ba9902204b74b2d1901a97166f10"
+source = "git+https://github.com/burokoron/yasai/?rev=b7bde8287d18b343920f4a9dd7e570729dd8d0ca#b7bde8287d18b343920f4a9dd7e570729dd8d0ca"
 dependencies = [
  "arrayvec",
  "cfg-if",

--- a/train/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/train/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 
 [profile.release]
@@ -9,6 +9,7 @@ lto = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+arrayvec = "0.7.4"
 encoding = "0.2.33"
 rand = "0.8.5"
 rand_distr = "0.4.3"
@@ -16,4 +17,4 @@ serde = { version = "1.0.139", features = ["derive"] }
 serde_json = "1.0.59"
 shogi_core = "0.1.4"
 shogi_usi_parser = "0.1.0"
-yasai = { git = "https://github.com/burokoron/yasai/", rev = "d38d6592a422ba9902204b74b2d1901a97166f10" }
+yasai = { git = "https://github.com/burokoron/yasai/", rev = "b7bde8287d18b343920f4a9dd7e570729dd8d0ca" }

--- a/train/bakuretsu_komahiroi_taro/src/evaluate.rs
+++ b/train/bakuretsu_komahiroi_taro/src/evaluate.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use shogi_core::{Color, Move, Piece, PieceKind, Square};
 use yasai::Position;
 
-pub const VALUE_SCALE: f32 = 256.;
+pub const VALUE_SCALE: f32 = 512.;
 
 #[derive(Deserialize, Serialize)]
 pub struct EvalJson {

--- a/train/bakuretsu_komahiroi_taro/src/search.rs
+++ b/train/bakuretsu_komahiroi_taro/src/search.rs
@@ -1,5 +1,6 @@
+use arrayvec::ArrayVec;
 use shogi_core::{Color, Move, Piece, PieceKind, Square};
-use std::collections::{HashMap, HashSet};
+use std::collections::HashSet;
 use yasai::Position;
 
 use crate::evaluate::Evaluate;
@@ -7,15 +8,13 @@ use crate::evaluate::VALUE_SCALE;
 
 pub const MATING_VALUE: i32 = 30000;
 
+#[derive(Clone)]
 pub struct HashTableValue {
-    depth: u32,
-    upper: i32,
-    lower: i32,
-    best_move: Option<Move>,
-}
-
-pub struct HashTable {
-    pub pos: HashMap<u64, HashTableValue>,
+    pub key: u64,
+    pub depth: u32,
+    pub upper: i32,
+    pub lower: i32,
+    pub best_move: Option<Move>,
 }
 
 pub struct MoveOrdering {
@@ -23,7 +22,7 @@ pub struct MoveOrdering {
     pub killer_heuristic: Vec<Vec<Option<Move>>>,
 }
 
-pub struct NegaAlpha<'a> {
+pub struct NegaAlpha {
     pub my_turn: Color,
     pub start_time: std::time::Instant,
     pub max_time: i32,
@@ -32,13 +31,13 @@ pub struct NegaAlpha<'a> {
     pub max_board_number: u16,
     pub best_move_pv: Option<Move>,
     pub is_eval_nyugyoku: bool,
-    pub eval: &'a Evaluate,
-    pub hash_table: HashTable,
+    pub eval: Evaluate,
+    pub hash_table: Vec<HashTableValue>,
     pub move_ordering: MoveOrdering,
     pub position_history: HashSet<u64>,
 }
 
-impl NegaAlpha<'_> {
+impl NegaAlpha {
     fn evaluate_diff(&mut self, pos: &mut Position, position_value: &[f32]) -> i32 {
         //! 局面の差分評価
         //!
@@ -227,7 +226,7 @@ impl NegaAlpha<'_> {
         let is_check = pos.in_check();
 
         // ムーブオーダリング
-        let mut move_list: Vec<(Move, i64)> = Vec::new();
+        let mut move_list = ArrayVec::<(Move, i64), 593>::new();
         // ムーブオーダリング用の重み計算
         for m in legal_moves {
             let mut value = 0;
@@ -332,12 +331,11 @@ impl NegaAlpha<'_> {
         }
 
         // 置換表の確認
-        let mut best_move = None;
-        let hash_table_value = self.hash_table.pos.get(&pos.key());
-        if let Some(hash_table_value) = hash_table_value {
-            if depth <= hash_table_value.depth {
-                let lower = hash_table_value.lower;
-                let upper = hash_table_value.upper;
+        let hash_table_index = pos.key() as usize % self.hash_table.len();
+        let mut best_move = if self.hash_table[hash_table_index].key == pos.key() {
+            if depth <= self.hash_table[hash_table_index].depth {
+                let lower = self.hash_table[hash_table_index].lower;
+                let upper = self.hash_table[hash_table_index].upper;
                 if lower >= beta {
                     return lower;
                 }
@@ -347,8 +345,10 @@ impl NegaAlpha<'_> {
                 alpha = alpha.max(lower);
                 beta = beta.min(upper);
             }
-            best_move = hash_table_value.best_move;
-        }
+            self.hash_table[hash_table_index].best_move
+        } else {
+            None
+        };
 
         // 探索深さ制限なら
         if depth == 0 {
@@ -412,7 +412,7 @@ impl NegaAlpha<'_> {
 
         // ムーブオーダリング
         let mut best_value = alpha;
-        let mut move_list: Vec<(Move, i64)> = Vec::new();
+        let mut move_list = ArrayVec::<(Move, i64), 593>::new();
         // ムーブオーダリング用の重み計算
         for m in legal_moves {
             let mut value = 0;
@@ -546,27 +546,20 @@ impl NegaAlpha<'_> {
         self.position_history.remove(&pos.key());
 
         // 置換表へ登録
-        let hash_table_value = self
-            .hash_table
-            .pos
-            .entry(pos.key())
-            .or_insert(HashTableValue {
-                depth: 0,
-                upper: MATING_VALUE,
-                lower: -MATING_VALUE,
-                best_move: None,
-            });
-        if depth > hash_table_value.depth {
+        if depth > self.hash_table[hash_table_index].depth {
+            self.hash_table[hash_table_index].key = pos.key();
+            self.hash_table[hash_table_index].depth = depth;
             if best_value <= alpha {
-                hash_table_value.upper = best_value;
+                self.hash_table[hash_table_index].upper = best_value;
+                self.hash_table[hash_table_index].lower = -MATING_VALUE;
             } else if best_value >= beta {
-                hash_table_value.lower = best_value;
+                self.hash_table[hash_table_index].upper = MATING_VALUE;
+                self.hash_table[hash_table_index].lower = best_value;
             } else {
-                hash_table_value.upper = best_value;
-                hash_table_value.lower = best_value;
+                self.hash_table[hash_table_index].upper = best_value;
+                self.hash_table[hash_table_index].lower = best_value;
             }
-            hash_table_value.depth = depth;
-            hash_table_value.best_move = best_move;
+            self.hash_table[hash_table_index].best_move = best_move;
         }
 
         best_value
@@ -595,29 +588,29 @@ impl NegaAlpha<'_> {
             if position_history.contains(&pos.key()) {
                 break;
             }
-            let hash_table = self.hash_table.pos.get(&pos.key());
-            if let Some(hash_table_value) = hash_table {
-                let best_move = hash_table_value.best_move;
-                if let Some(best_move) = best_move {
-                    let legal_moves = pos.legal_moves();
-                    let mut is_legal = false;
-                    for m in legal_moves {
-                        if m == best_move {
-                            is_legal = true;
-                            break;
-                        }
-                    }
-                    if !is_legal {
+            let hash_table_index = pos.key() as usize % self.hash_table.len();
+            let best_move = if self.hash_table[hash_table_index].key == pos.key() {
+                self.hash_table[hash_table_index].best_move
+            } else {
+                None
+            };
+            if let Some(best_move) = best_move {
+                let legal_moves = pos.legal_moves();
+                let mut is_legal = false;
+                for m in legal_moves {
+                    if m == best_move {
+                        is_legal = true;
                         break;
                     }
-                    pv += &move_to_sfen(best_move);
-                    pv += " ";
-                    position_history.insert(pos.key());
-                    pos.do_move(best_move);
-                    moves.push(best_move);
-                } else {
+                }
+                if !is_legal {
                     break;
                 }
+                pv += &move_to_sfen(best_move);
+                pv += " ";
+                position_history.insert(pos.key());
+                pos.do_move(best_move);
+                moves.push(best_move);
             } else {
                 break;
             }


### PR DESCRIPTION
#63 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: `bakuretsu_komahiroi_taro`パッケージのバージョンを2.2.2および3.0.1に更新し、Rustエディションを2021に指定
- Chore: 依存関係に`arrayvec`バージョン0.7.4を追加し、`yasai`のリビジョンを更新
- New Feature: テキスト処理機能を拡張するため、`markdown-it-py`、`mdurl`、`Pygments`、`rich`を依存関係に追加
- Refactor: 評価関数の精度向上のため、`VALUE_SCALE`の値を256から512に変更
- Refactor: 検索アルゴリズムのパフォーマンスとメモリ効率改善のため、ハッシュテーブルの実装を大幅に変更
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->