### PR TITLE
爆裂駒拾太郎V2.2.3

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "2.2.2"
+version = "2.2.3"
 dependencies = [
  "arrayvec",
  "encoding",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "2.2.2"
+version = "2.2.3"
 edition = "2021"
 
 [profile.release]

--- a/engine/bakuretsu_komahiroi_taro/src/main.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/main.rs
@@ -92,9 +92,11 @@ impl BakuretsuKomahiroiTaro {
                         upper: MATING_VALUE,
                         lower: -MATING_VALUE,
                         best_move: None,
+                        generation: 0,
                     };
-                    20000000
+                    5000000
                 ],
+                hash_table_generation: 0,
                 move_ordering: search::MoveOrdering {
                     piece_to_history: vec![vec![vec![0; 81]; 14]; 2],
                     killer_heuristic: vec![vec![None; 2]; self.depth_limit as usize + 1],
@@ -269,13 +271,7 @@ impl BakuretsuKomahiroiTaro {
             searcher.max_depth = 1;
             searcher.max_board_number = pos.ply();
             searcher.best_move_pv = None;
-            searcher.hash_table.fill(search::HashTableValue {
-                key: 0,
-                depth: 0,
-                upper: MATING_VALUE,
-                lower: -MATING_VALUE,
-                best_move: None,
-            });
+            searcher.hash_table_generation += 1;
             searcher.move_ordering = search::MoveOrdering {
                 piece_to_history: vec![vec![vec![0; 81]; 14]; 2],
                 killer_heuristic: vec![vec![None; 2]; self.depth_limit as usize + 1],


### PR DESCRIPTION
#65 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: `bakuretsu_komahiroi_taro`のバージョンを`2.2.3`に更新し、エディションは2021を維持
- Performance: 検索深度の制限値を20,000,000から5,000,000に減少させ、探索アルゴリズムのパフォーマンス向上
- Feature: ハッシュテーブルの世代管理機能を導入し、探索アルゴリズムの正確性と効率性を改善
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->