### PR TITLE
Rust 1.78に対応

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/src/main.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/main.rs
@@ -276,7 +276,7 @@ impl BakuretsuKomahiroiTaro {
                 piece_to_history: vec![vec![vec![0; 81]; 14]; 2],
                 killer_heuristic: vec![vec![None; 2]; self.depth_limit as usize + 1],
             };
-            searcher.position_history = position_history.clone();
+            searcher.position_history.clone_from(position_history);
 
             // 探索
             let mut position_value = vec![searcher.eval.inference_diff(pos, None, None); 1];

--- a/train/bakuretsu_komahiroi_taro/src/main.rs
+++ b/train/bakuretsu_komahiroi_taro/src/main.rs
@@ -276,7 +276,7 @@ impl BakuretsuKomahiroiTaro {
                 piece_to_history: vec![vec![vec![0; 81]; 14]; 2],
                 killer_heuristic: vec![vec![None; 2]; self.depth_limit as usize + 1],
             };
-            searcher.position_history = position_history.clone();
+            searcher.position_history.clone_from(position_history);
 
             // 現在の局面が通常の評価関数で評価値が一定以下(互角)ならそのまま、そうでないなら入玉用評価関数に変更
             let mut position_value = vec![searcher.eval.inference_diff(pos, None, None); 1];


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Refactor: `bakuretsu_komahiroi_taro`エンジンのパフォーマンス向上のため、`position_history`変数のクローン作成方法を`clone`メソッドから`clone_from`メソッドへ変更しました。これにより、特定のシナリオでの処理速度が改善されます。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->