### PR TITLE
爆裂駒拾太郎V3.0.1

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "arrayvec",
  "encoding",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 
 [profile.release]

--- a/engine/bakuretsu_komahiroi_taro/src/search.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/search.rs
@@ -161,7 +161,7 @@ impl NegaAlpha {
                     }
                 }
             }
-            if is_check || value > 0 {
+            if is_check || pos.is_check_move(m) || value > 0 {
                 move_list.push((m, value));
             }
         }


### PR DESCRIPTION
#74 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Bug fix: `move_list`に手を追加する条件が修正され、チェック状態の判定が強化されました。これにより、手の評価がより正確になります。
- Chore: `bakuretsu_komahiroi_taro`パッケージのバージョンが`3.0.0`から`3.0.1`に更新されました。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->