### PR TITLE
爆裂駒拾太郎V3.0.2

### DIFF
--- a/engine/bakuretsu_komahiroi_taro/Cargo.lock
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.lock
@@ -16,7 +16,7 @@ checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "arrayvec",
  "encoding",

--- a/engine/bakuretsu_komahiroi_taro/Cargo.toml
+++ b/engine/bakuretsu_komahiroi_taro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bakuretsu_komahiroi_taro"
-version = "3.0.1"
+version = "3.0.2"
 edition = "2021"
 
 [profile.release]

--- a/engine/bakuretsu_komahiroi_taro/src/search.rs
+++ b/engine/bakuretsu_komahiroi_taro/src/search.rs
@@ -394,7 +394,7 @@ impl NegaAlpha {
             ));
             pos.do_move(m.0);
             // Late Move Reductions
-            if is_lmr && move_count >= 6 && !pos.in_check() {
+            if is_lmr && move_count >= 11 && !pos.in_check() {
                 let value = -self.search(pos, position_value, false, depth - 2, -beta, -best_value);
                 if value <= best_value {
                     pos.undo_move(m.0);
@@ -407,7 +407,7 @@ impl NegaAlpha {
             if best_value < value {
                 best_value = value;
                 best_move = Some(m.0);
-                if is_lmr && move_count < 6 {
+                if is_lmr && move_count < 11 {
                     is_lmr = false;
                 }
                 if depth == self.max_depth {


### PR DESCRIPTION
#76 
<!-- This is an auto-generated comment: release notes by OSS CodeRabbit -->
### Summary by CodeRabbit

```
- Chore: `bakuretsu_komahiroi_taro`パッケージのバージョンを`3.0.1`から`3.0.2`に更新しました。
- Refactor: Late Move Reductions（LMR）の条件を調整し、`move_count`の閾値を6から11に変更しました。これにより、LMRが適用される条件が変更され、検索アルゴリズムの効率が向上する可能性があります。
```
<!-- end of auto-generated comment: release notes by OSS CodeRabbit -->